### PR TITLE
fix(Search): Make free text search case insensitive

### DIFF
--- a/src/components/Explore/ByFrameRepeater.tsx
+++ b/src/components/Explore/ByFrameRepeater.tsx
@@ -20,6 +20,7 @@ import { debounce } from 'lodash';
 import { Search } from './Search';
 import { getGroupByVariable } from 'utils/utils';
 import { EventTimeseriesDataReceived, GRID_TEMPLATE_COLUMNS } from '../../utils/shared';
+import { doesQueryMatchDataFrameLabels } from './helpers/doesQueryMatchDataFrameLabels';
 
 interface ByFrameRepeaterState extends SceneObjectState {
   body: SceneLayout;
@@ -54,11 +55,9 @@ export class ByFrameRepeater extends SceneObjectBase<ByFrameRepeaterState> {
             } else {
               const filtered = {
                 ...data.data,
-                series: data.data?.series.filter((frame) => {
-                  return frame.fields.some((f) => !f.labels ? false : Object.values(f.labels).find((label) => label.toLowerCase().includes(this.state.searchQuery ?? '')));
-                }),
+                series: data.data?.series.filter(doesQueryMatchDataFrameLabels(this.state.searchQuery)),
               };
-              this.renderFilteredData(filtered as PanelData);              
+              this.renderFilteredData(filtered as PanelData);
               this.publishEvent(new EventTimeseriesDataReceived({ series: data.data.series }), true);
             }
           } else if (data.data?.state === LoadingState.Error) {
@@ -109,9 +108,7 @@ export class ByFrameRepeater extends SceneObjectBase<ByFrameRepeaterState> {
     const data = sceneGraph.getData(this);
     const filtered = {
       ...data.state.data,
-      series: data.state.data?.series.filter((frame) => {
-        return frame.fields.some((f) => !f.labels ? false : Object.values(f.labels).find((label) => label.toLowerCase().includes(searchQuery)));
-      }),
+      series: data.state.data?.series.filter(doesQueryMatchDataFrameLabels(searchQuery)),
     };
     this.renderFilteredData(filtered as PanelData);
   }, 250);

--- a/src/components/Explore/helpers/__tests__/doesQueryMatchDataFrameLabels.spec.ts
+++ b/src/components/Explore/helpers/__tests__/doesQueryMatchDataFrameLabels.spec.ts
@@ -1,0 +1,100 @@
+import { FieldType } from '@grafana/data';
+import { doesQueryMatchDataFrameLabels } from '../doesQueryMatchDataFrameLabels';
+
+const DATA_FRAME_FIELDS = [
+  {
+    type: FieldType.number,
+    config: {},
+    values: [],
+    name: '{resource.service.name="mythical-requester", status="error"}',
+    labels: { 'resource.service.name': '"mythical-requester"', status: '"error"' },
+  },
+  {
+    type: FieldType.number,
+    config: {},
+    values: [],
+    name: '{resource.service.name="mythical-requester", status="ok"}',
+    labels: { 'resource.service.name': '"mythical-requester"', status: '"ok"' },
+  },
+];
+
+describe('doesQueryMatchDataFrameLabels', () => {
+  describe('when there are no fields in the data frame', () => {
+    test('returns false', () => {
+      expect(doesQueryMatchDataFrameLabels('needle')({ fields: [], length: 0 })).toBe(false);
+    });
+  });
+
+  describe('when there are fields in the data frame', () => {
+    test.each([
+      [
+        'no labels in the fields',
+        'requester',
+        false,
+        [
+          {
+            type: FieldType.number,
+            config: {},
+            values: [],
+            name: '{resource.service.name="mythical-requester", status="error"}',
+            labels: undefined,
+          },
+          {
+            type: FieldType.number,
+            config: {},
+            values: [],
+            name: '{resource.service.name="mythical-requester", status="ok"}',
+            labels: undefined,
+          },
+        ],
+      ],
+      ['labels in the fields & an empty search query', '', true, DATA_FRAME_FIELDS],
+      ['labels in the fields & a search match', 'requester', true, DATA_FRAME_FIELDS],
+      ['labels in the fields & a search query with spaces around', '  requester  ', true, DATA_FRAME_FIELDS],
+      [
+        'labels in the fields & a case-sensitive search match (#1)',
+        'MYTHICAL',
+        true,
+        [
+          {
+            type: FieldType.number,
+            config: {},
+            values: [],
+            name: '{resource.service.name="mythical-requester", status="error"}',
+            labels: { 'resource.service.name': '"mythical-requester"', status: '"error"' },
+          },
+          {
+            type: FieldType.number,
+            config: {},
+            values: [],
+            name: '{resource.service.name="MYTHICAL-requester", status="ok"}',
+            labels: { 'resource.service.name': '"MYTHICAL-requester"', status: '"ok"' },
+          },
+        ],
+      ],
+      [
+        'labels in the fields & a case-sensitive search match (#2)',
+        'mythical',
+        true,
+        [
+          {
+            type: FieldType.number,
+            config: {},
+            values: [],
+            name: '{resource.service.name="MYTHICAL-requester", status="error"}',
+            labels: { 'resource.service.name': '"MYTHICAL-requester"', status: '"error"' },
+          },
+          {
+            type: FieldType.number,
+            config: {},
+            values: [],
+            name: '{resource.service.name="MYTHICAL-requester", status="ok"}',
+            labels: { 'resource.service.name': '"MYTHICAL-requester"', status: '"ok"' },
+          },
+        ],
+      ],
+    ])('%s, "%s" → %s', (_, searchQuery, expectedOutput, fields) => {
+      expect(doesQueryMatchDataFrameLabels(searchQuery)({ fields, length: 42 })).toBe(expectedOutput);
+    });
+  });
+});

--- a/src/components/Explore/helpers/doesQueryMatchDataFrameLabels.ts
+++ b/src/components/Explore/helpers/doesQueryMatchDataFrameLabels.ts
@@ -1,0 +1,12 @@
+import { DataFrame } from '@grafana/data';
+
+export const doesQueryMatchDataFrameLabels = (searchQuery?: string) => (dataFrame: DataFrame) => {
+  const pattern = searchQuery?.trim();
+  if (!pattern) {
+    return true;
+  }
+
+  const regex = new RegExp(pattern, 'i');
+
+  return dataFrame.fields.some((f) => (!f.labels ? false : Object.values(f.labels).find((label) => regex.test(label))));
+};


### PR DESCRIPTION
### Description 

**Related issue** resolves https://github.com/grafana/explore-traces/issues/250

### Summary of the changes

In order to prevent some results to be absent from the free text search, this PR makes the search case-insensitive.

Idea for the future: adding a text case toggle, like we have in the Explore Logs app

<img width="626" alt="image" src="https://github.com/user-attachments/assets/d9d7413d-06c7-4a86-b206-3d19fd147fb5">

### How to test

- The new unit tests should pass
- Manually, by reproducing the context described in the related issue

