### PR TITLE
[DOC] Add blog post link and TraceQL metrics requirements

### DIFF
--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -64,9 +64,11 @@ Using the app, you can:
 * Browse automatic visualizations of your data based on its characteristics
 * Do all of this without writing TraceQL queries
 
-{{< youtube id="a3uB1C2oHA4" >}}
+To learn more, read:
+* [From multi-line queries to no-code investigations: meeting Grafana users where they are](https://grafana.com/blog/2024/10/22/from-multi-line-queries-to-no-code-investigations-meeting-grafana-users-where-they-are/)
+* [A queryless experience for exploring metrics, logs, traces, and profiles: Introducing the Explore apps suite for Grafana](https://grafana.com/blog/2024/09/24/queryless-metrics-logs-traces-profiles/).
 
-![The Explore Traces app](explore-traces-homescreen.png)
+{{< youtube id="a3uB1C2oHA4" >}}
 
 ## Explore
 

--- a/docs/sources/access/index.md
+++ b/docs/sources/access/index.md
@@ -24,7 +24,7 @@ You can access Explore Traces using any of these:
  - [Grafana Cloud](access-in-grafana-cloud): The easiest method, since no setup or installation is required.
  - Self-managed [Grafana](#access-in-self-managed-grafana) open source or Enterprise: You must install the Explore Traces plugin.
 
-Explore Traces requires Tempo 2.6 or later.
+Explore Traces requires Grafana Tempo 2.6 or later with [TraceQL metrics configured](https://grafana.com/docs/tempo/<TEMPO_VERSION>/operations/traceql-metrics/).
 
 ## Set up in Grafana Cloud
 

--- a/docs/sources/access/index.md
+++ b/docs/sources/access/index.md
@@ -38,7 +38,7 @@ To use Explore Traces with Grafana Cloud, you need the following:
 To use Explore Traces with self-managed Grafana open source or Grafana Enterprise, you need:
 
 - Your own Grafana instance running 11.2 or later
-- Tempo 2.6 or later
+- Tempo 2.6 or later with [TraceQL metrics configured](https://grafana.com/docs/tempo/<TEMPO_VERSION>/operations/traceql-metrics/)
 - Configured [Tempo data source](https://grafana.com/docs/grafana/latest/datasources/tempo/configure-tempo-data-source/) receiving tracing data
 
 Next, [access Explore Traces](#access-explore-traces).


### PR DESCRIPTION
Adds a link to the new Explore apps blog and updates the Install on self-hosted Grafana to include TraceQL metrics.