### PR TITLE
Add filter to homepage

### DIFF
--- a/src/components/Explore/filters/FilterByVariable.tsx
+++ b/src/components/Explore/filters/FilterByVariable.tsx
@@ -6,6 +6,7 @@ import { VariableHide } from '@grafana/schema';
 
 import { FilterSetRenderer } from './FilterSetRenderer';
 import { VAR_FILTERS, explorationDS } from 'utils/shared';
+import { isNumber } from 'utils/utils';
 
 export type FilterByVariableState = ConstructorParameters<typeof AdHocFiltersVariable>[0] & {
   initialFilters?: AdHocVariableFilter[];
@@ -35,7 +36,6 @@ export function renderTraceQLLabelFilters(filters: AdHocVariableFilter[]) {
   // and avoid invalid queries like '{ && key=value }'
   return expr.length ? expr : 'true';
 }
-const isNumber = /^-?\d+\.?\d*$/;
 
 function renderFilter(filter: AdHocVariableFilter) {
   let val = filter.value;

--- a/src/components/Home/AttributePanel.tsx
+++ b/src/components/Home/AttributePanel.tsx
@@ -28,6 +28,7 @@ export interface AttributePanelState extends SceneObjectState {
   title: string;
   type: MetricFunction;
   renderDurationPanel?: boolean;
+  filter?: string;
 }
 
 export class AttributePanel extends SceneObjectBase<AttributePanelState> {
@@ -35,7 +36,7 @@ export class AttributePanel extends SceneObjectBase<AttributePanelState> {
     super({
       $data: new SceneQueryRunner({
         datasource: explorationDS,
-        queries: [{ refId: 'A', queryType: 'traceql', tableType: 'spans', limit: 10, ...state.query }],
+        queries: [{ refId: 'A', queryType: 'traceql', tableType: 'spans', limit: 10, ...state.query, exemplars: 0 }],
       }),
       ...state,
     });
@@ -82,7 +83,7 @@ export class AttributePanel extends SceneObjectBase<AttributePanelState> {
                       children: [
                         new AttributePanel({ 
                           query: {
-                            query: `{nestedSetParent<0 && kind=server && duration > ${minDuration}}`,
+                            query: `{nestedSetParent<0 && duration > ${minDuration} ${state.filter ? state.filter : ''}}`,
                           },
                           title: state.title, 
                           type: state.type,

--- a/src/components/Home/AttributePanelRows.tsx
+++ b/src/components/Home/AttributePanelRows.tsx
@@ -5,6 +5,7 @@ import React from "react";
 import { formatDuration } from "utils/dates";
 import { EXPLORATIONS_ROUTE, MetricFunction, ROUTES } from "utils/shared";
 import { AttributePanelRow } from "./AttributePanelRow";
+import { getLabelKey, getLabelValue } from "utils/utils";
 
 type Props = {
   series?: DataFrame[];
@@ -33,15 +34,12 @@ export const AttributePanelRows = (props: Props) => {
 
   if (series && series.length > 0) {
     if (type === 'errors') {
-      const getLabel = (df: DataFrame) => {
-        const valuesField = df.fields.find((f) => f.name !== 'time');
-        return valuesField?.labels?.['resource.service.name'].replace(/"/g, '') ??  'Service name not found';
-      }
-
       const getUrl = (df: DataFrame) => {
-        const serviceName = getLabel(df);
+        const labelKey = getLabelKey(df);
+        const labelValue = getLabelValue(df);
+
         const params = {
-          'var-filters': `resource.service.name|=|${serviceName}`,
+          'var-filters': `${labelKey}|=|${labelValue}`,
           'var-metric': type,
         }
         const url = urlUtil.renderUrl(EXPLORATIONS_ROUTE, params);
@@ -67,8 +65,8 @@ export const AttributePanelRows = (props: Props) => {
               <AttributePanelRow 
                 type={type} 
                 index={index}
-                label={getLabel(df)}
-                labelTitle='Service'
+                label={getLabelValue(df)}
+                labelTitle={getLabelKey(df)}
                 value={getTotalErrs(df)}
                 valueTitle='Total errors'
                 url={getUrl(df)}

--- a/src/components/Home/HeaderScene.tsx
+++ b/src/components/Home/HeaderScene.tsx
@@ -11,14 +11,14 @@ import { Button, Icon, LinkButton, Stack, useStyles2, useTheme2 } from '@grafana
 import {
   EXPLORATIONS_ROUTE,
 } from '../../utils/shared';
-import { getDatasourceVariable, getHomeScene } from '../../utils/utils';
+import { getDatasourceVariable, getHomeFilterVariable, getHomeScene } from '../../utils/utils';
 import { useNavigate } from 'react-router-dom-v5-compat';
-import { Home } from 'pages/Home/Home';
 import { DarkModeRocket, LightModeRocket } from '../../utils/rockets';
 import { reportAppInteraction, USER_EVENTS_ACTIONS, USER_EVENTS_PAGES } from 'utils/analytics';
+import { Home } from 'pages/Home/Home';
 
 export class HeaderScene extends SceneObjectBase {
-  static Component = ({ model }: SceneComponentProps<Home>) => {
+  public static Component = ({ model }: SceneComponentProps<Home>) => {
     const home = getHomeScene(model);
     const navigate = useNavigate();
     const { controls } = home.useState();
@@ -26,6 +26,7 @@ export class HeaderScene extends SceneObjectBase {
     const theme = useTheme2();
 
     const dsVariable = getDatasourceVariable(home);
+    const filterVariable = getHomeFilterVariable(home);
 
     return (
       <div className={styles.container}>
@@ -66,16 +67,27 @@ export class HeaderScene extends SceneObjectBase {
         </div>
 
         <Stack gap={2}>
-          {dsVariable && (
-            <Stack gap={1} alignItems={'center'}>
-              <div className={styles.datasourceLabel}>Data source</div>
-              <dsVariable.Component model={dsVariable} />
-            </Stack>
-          )}
-          <div className={styles.controls}>
-            {controls.map((control) => (
-              <control.Component key={control.state.key} model={control} />
-            ))}
+          <div className={styles.variablesAndControls}>
+            <div className={styles.variables}>
+              {dsVariable && (
+                <Stack gap={1} alignItems={'center'}>
+                  <div className={styles.label}>Data source</div>
+                  <dsVariable.Component model={dsVariable} />
+                </Stack>
+              )}
+              {filterVariable && (
+                <Stack gap={1} alignItems={'center'}>
+                  <div className={styles.label}>Filter</div>
+                  <filterVariable.Component model={filterVariable} />
+                </Stack>
+              )}
+            </div>
+
+            <div className={styles.controls}>
+              {controls?.map((control) => (
+                <control.Component key={control.state.key} model={control} />
+              ))}
+            </div>
           </div>
         </Stack>
       </div>
@@ -130,8 +142,19 @@ function getStyles(theme: GrafanaTheme2) {
       }
     }),
 
-    datasourceLabel: css({
+    label: css({
       fontSize: '12px',
+    }),
+    variablesAndControls: css({
+      alignItems: 'center',
+      gap: theme.spacing(2),
+      display: 'flex',
+      justifyContent: 'space-between',
+      width: '100%',
+    }),
+    variables: css({
+      display: 'flex',
+      gap: theme.spacing(2),
     }),
     controls: css({
       display: 'flex',

--- a/src/components/Home/HomeFilter.tsx
+++ b/src/components/Home/HomeFilter.tsx
@@ -1,0 +1,114 @@
+import { css } from '@emotion/css';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { GrafanaTheme2, SelectableValue } from '@grafana/data';
+import { Select, useStyles2 } from '@grafana/ui';
+import { EVENT_ATTR, EVENT_INTRINSIC, ignoredAttributes, ignoredAttributesHomeFilter, RESOURCE_ATTR, SPAN_ATTR } from 'utils/shared';
+import { HomeFilterVariable } from './HomeFilterVariable';
+import { getDatasourceVariable } from 'utils/utils';
+import { reportAppInteraction, USER_EVENTS_ACTIONS, USER_EVENTS_PAGES } from 'utils/analytics';
+
+type Props = {
+  model: HomeFilterVariable;
+};
+
+export function HomeFilter(props: Props) {
+  const { model } = props;
+  const { filters } = model.useState();
+  const dsVariable = getDatasourceVariable(model).useState();
+  const styles = useStyles2(getStyles);
+
+  const [state, setState] = useState<{
+    keys?: SelectableValue[];
+    values?: SelectableValue[];
+    isKeysLoading?: boolean;
+    isValuesLoading?: boolean;
+  }>({});
+  
+  const updateKeys = useCallback(async () => {
+    setState({ ...state, isKeysLoading: true });
+    const keys = await model._getKeys(filters[0].key);
+    setState({ ...state, isKeysLoading: false, keys });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    updateKeys();
+  }, [dsVariable, updateKeys]);
+  
+  const keyOptions = useMemo(() => {
+    if (!state.keys) {
+      return [];
+    }
+
+    const resourceAttributes = state.keys.filter((k) => k.value?.includes(RESOURCE_ATTR));
+    const spanAttributes = state.keys.filter((k) => k.value?.includes(SPAN_ATTR));
+    const intrinsicAttributes = state.keys.filter((k) => {
+      return !k.value?.includes(RESOURCE_ATTR) && !k.value?.includes(SPAN_ATTR)
+        && !k.value?.includes(EVENT_ATTR) && !k.value?.includes(EVENT_INTRINSIC)
+        && ignoredAttributes.concat(ignoredAttributesHomeFilter).indexOf(k.value!) === -1;
+    })
+
+    return [...resourceAttributes, ...spanAttributes, ...intrinsicAttributes];
+  }, [state.keys]);
+
+  const valueOptions = useMemo(() => {
+    if (!state.values) {
+      return [];
+    }
+
+    return state.values.sort((a, b) => (a.label ?? '').localeCompare((b.label ?? '')));
+  }, [state.values]);
+
+  return (
+    <div className={styles.container}>
+      <Select
+        className={styles.select}
+        value={(filters.length > 0 && filters?.[0].key) ?? ''}
+        placeholder={'attribute'}
+        options={keyOptions}
+        onChange={(v) => { 
+          reportAppInteraction(USER_EVENTS_PAGES.home, USER_EVENTS_ACTIONS.home.filter_changed, {
+            type: 'key'
+          });
+          model._updateFilter(filters[0], { key: v?.value ?? '', value: '' })
+        }}
+        isLoading={state.isKeysLoading}
+        virtualized
+      />
+      <Select        
+        className={styles.select}
+        key={`${(filters.length > 0 && filters?.[0].value) ?? ''}`}
+        value={(filters.length > 0 && filters?.[0].value) ?? ''}
+        placeholder={'value'}
+        options={valueOptions}
+        onChange={(v) => {
+          reportAppInteraction(USER_EVENTS_PAGES.home, USER_EVENTS_ACTIONS.home.filter_changed, {
+            type: 'value'
+          });
+          model._updateFilter(filters[0], { value: v?.value ?? '' })
+        }}
+        isLoading={state.isValuesLoading}
+        onOpenMenu={async () => {
+          setState({ ...state, isValuesLoading: true, values: [] });
+          const values = await model._getValuesFor(filters[0]);
+          setState({ ...state, isValuesLoading: false, values });
+        }}
+        virtualized
+        isClearable
+      />
+    </div>
+  );
+}
+
+function getStyles(theme: GrafanaTheme2) {
+  return {
+    container: css({
+      display: 'flex',
+      gap: theme.spacing(1),
+    }),
+    select: css({
+      width: `max-content !important`,
+    }),
+  };
+}

--- a/src/components/Home/HomeFilterVariable.tsx
+++ b/src/components/Home/HomeFilterVariable.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+import { AdHocVariableFilter } from '@grafana/data';
+import { AdHocFiltersVariable, SceneComponentProps } from '@grafana/scenes';
+import { VariableHide } from '@grafana/schema';
+
+import { VAR_HOME_FILTER, explorationDS } from 'utils/shared';
+import { HomeFilter } from './HomeFilter';
+
+export type HomeFilterVariableState = ConstructorParameters<typeof AdHocFiltersVariable>[0] & {
+  initialFilters: AdHocVariableFilter[];
+};
+
+export class HomeFilterVariable extends AdHocFiltersVariable {
+  static Component = ({ model }: SceneComponentProps<HomeFilterVariable>) => <HomeFilter model={model} />;
+
+  constructor({ initialFilters }: HomeFilterVariableState) {
+    super({
+      hide: VariableHide.hideLabel,
+      name: VAR_HOME_FILTER,
+      datasource: explorationDS,
+      layout: 'horizontal',
+      filters: initialFilters,
+    });
+  }
+}

--- a/src/pages/Home/HomePage.tsx
+++ b/src/pages/Home/HomePage.tsx
@@ -6,7 +6,7 @@ import { Home } from './Home';
 
 const HomePage = () => {
   const initialDs = localStorage.getItem(DATASOURCE_LS_KEY) || '';
-  const [home] = useState(newHome(initialDs));
+  const [home] = useState(newHome([{ key: 'resource.service.name', operator: '=', value: '' }], initialDs));
 
   return <HomeView home={home} />;
 };

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -44,6 +44,7 @@ export const USER_EVENTS_ACTIONS = {
     panel_row_clicked: 'panel_row_clicked',
     explore_traces_clicked: 'explore_traces_clicked',
     read_documentation_clicked: 'read_documentation_clicked',
+    filter_changed: 'filter_changed',
   },
   [USER_EVENTS_PAGES.common]: {
     metric_changed: 'metric_changed',

--- a/src/utils/shared.ts
+++ b/src/utils/shared.ts
@@ -23,6 +23,7 @@ export const VAR_DATASOURCE = 'ds';
 export const VAR_DATASOURCE_EXPR = '${ds}';
 export const VAR_FILTERS = 'filters';
 export const VAR_FILTERS_EXPR = '${filters}';
+export const VAR_HOME_FILTER = 'homeFilter';
 export const VAR_GROUPBY = 'groupBy';
 export const VAR_METRIC = 'metric';
 export const VAR_LATENCY_THRESHOLD = 'latencyThreshold';
@@ -36,6 +37,8 @@ export const RESOURCE = 'Resource';
 export const SPAN = 'Span';
 export const RESOURCE_ATTR = 'resource.';
 export const SPAN_ATTR = 'span.';
+export const EVENT_ATTR = 'event.';
+export const EVENT_INTRINSIC = 'event:';
 
 export const radioAttributesResource = [
   // https://opentelemetry.io/docs/specs/semconv/resource/
@@ -74,6 +77,16 @@ export const ignoredAttributes = [
   'trace:duration',
   'trace:id',
   'traceDuration',
+];
+export const ignoredAttributesHomeFilter = [
+  'status',
+  'span:status',
+  'rootName', 
+  'rootService',
+  'rootServiceName', 
+  'trace:rootName', 
+  'trace:rootService',
+  'trace:rootServiceName'
 ];
 // Limit maximum options in select dropdowns for performance reasons
 export const maxOptions = 1000;


### PR DESCRIPTION
- Adds a filter to the homepage which can update the query.
- Set to `resource.service.name` by default.
- If only attribute is set, it will be used in the `by` section of the query (for errors).
- If value is also set, `attribute=value` will be used in the `{ .. }` section of the query (for errors and duration).

Internal user interviews showed us that users would like the ability to select which service/cluster/etc that are most interested in or simply to see errors/slow traces for an attribute other than `resource.service.name`. Having spoken with @nadinevehling & @alexbikfalvi, we decided to allow users to add an optional filter for this iteration and based on feedback we will decide if we want to allow them to add more than one filter/create views (something like what Explore Logs does), but for this iteration it was requested to walk before we run :D 

Next enhancements;
- Remember the users last filter,
- Limit values in the dropdown

![Screenshot 2025-02-06 at 15 36 55](https://github.com/user-attachments/assets/8b074305-42a6-40a5-8894-e810f1b80130)
